### PR TITLE
feat: add optimistic client-side game state update

### DIFF
--- a/frontend/src/context/WebSocketContext.jsx
+++ b/frontend/src/context/WebSocketContext.jsx
@@ -210,6 +210,7 @@ export const WebSocketProvider = ({ children }) => {
         send,
         disconnect,
         gameState,
+        setGameState,
         isConnected,
         gameId,
       }}

--- a/frontend/src/hooks/useGame.js
+++ b/frontend/src/hooks/useGame.js
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import applyMove from "../utils/applyMove";
 import { useWebSocket } from "../context/WebSocketContext";
 import { gameStorage } from "../utils/storage";
 
@@ -11,6 +12,7 @@ export function useGame() {
     send,
     disconnect,
     gameState,
+    setGameState,
     isConnected,
   } = useWebSocket();
 
@@ -65,9 +67,15 @@ export function useGame() {
 
   const sendMove = useCallback(
     (move) => {
+      // Optimistically update the local game state before the server responds.
+      // This eliminates the perceived lag from the round-trip to the server.
+      const optimisticState = applyMove(gameState, move);
+      if (optimisticState) {
+        setGameState(optimisticState);
+      }
       send(JSON.stringify({ message: { type: "newMove", move } }));
     },
-    [send],
+    [send, gameState, setGameState],
   );
 
   const exitGame = useCallback(() => {

--- a/frontend/src/utils/applyMove.js
+++ b/frontend/src/utils/applyMove.js
@@ -1,0 +1,72 @@
+/**
+ * Client-side move applicator that mirrors backend apply_move logic.
+ * Used for optimistic UI updates to avoid waiting for server round-trip.
+ *
+ * Mirrors: backend/baghchal/utils.py :: apply_move()
+ */
+
+/**
+ * Calculates the middle key between two board positions for capture validation.
+ * @param {string} fromKey - e.g. "0-0"
+ * @param {string} toKey - e.g. "2-2"
+ * @returns {string} middle key e.g. "1-1"
+ */
+const getMidKey = (fromKey, toKey) => {
+  const [fromRow, fromCol] = fromKey.split("-").map(Number);
+  const [toRow, toCol] = toKey.split("-").map(Number);
+  const midRow = (fromRow + toRow) / 2;
+  const midCol = (fromCol + toCol) / 2;
+  return `${midRow}-${midCol}`;
+};
+
+/**
+ * Applies a validated move to the game state and returns a new state.
+ * Returns null if the move type is unrecognized.
+ *
+ * @param {object} gameState - Current game state
+ * @param {object} move - Move object { moveType, fromKey, toKey, currentPlayer }
+ * @returns {object|null} New game state after applying the move, or null on failure
+ */
+const applyMove = (gameState, move) => {
+  // Deep copy to avoid mutating existing state
+  const newState = JSON.parse(JSON.stringify(gameState));
+
+  const board = newState.board;
+  const currentPlayer = newState.currentPlayer;
+  const { moveType, fromKey, toKey } = move;
+
+  newState.isCaptured = false;
+
+  if (moveType === "place") {
+    board[toKey] = "goat";
+    newState.unusedGoat -= 1;
+    if (newState.unusedGoat === 0) {
+      newState.phase = "displacement";
+    }
+  } else if (moveType === "displace") {
+    const piece = board[fromKey];
+    delete board[fromKey];
+    board[toKey] = piece;
+  } else if (moveType === "capture") {
+    const piece = board[fromKey];
+    delete board[fromKey];
+    board[toKey] = piece;
+    const midKey = getMidKey(fromKey, toKey);
+    if (board[midKey] === "goat") {
+      delete board[midKey];
+      newState.deadGoatCount += 1;
+      newState.isCaptured = true;
+    }
+  } else {
+    return null;
+  }
+
+  // Switch player
+  newState.currentPlayer = currentPlayer === "goat" ? "tiger" : "goat";
+  newState.newPosition = toKey;
+  newState.previousPosition = fromKey || null;
+
+  return newState;
+};
+
+export default applyMove;


### PR DESCRIPTION
## Summary

Fixes #25 - eliminates laggy board updates from server round-trip after each move.

**Changes:**
- Added applyMove.js: JS port of backend apply_move() for local move application
- Modified WebSocketContext.jsx: exports setGameState to consumers
- Modified useGame.js sendMove: applies optimistic state update before sending to server

Server response still replaces local state for correctness.

## Test plan
- Place a goat: board updates immediately
- Displace a tiger: piece moves instantly
- Tiger captures: goat disappears and tiger moves instantly
- Server state overwrites local after response arrives